### PR TITLE
Add XML markup generation for histograms

### DIFF
--- a/R/AddXMLInternal.R
+++ b/R/AddXMLInternal.R
@@ -102,12 +102,34 @@
     annotations
 }
 
-
+## Constructs the center of the histogram 
 .AddXMLaddHistogramCenter = function(root, mids=NULL, counts=NULL, density=NULL, breaks=NULL) {
     annotation = .AddXMLaddAnnotation(root, position=4, id="center", kind="grouped")
     XML::addAttributes(annotation$root, speech="Histogram bars",
                        speech2=paste("Histogram with", length(mids), "bars"),
                        type="Center")
+    annotations <- list()
+    for (i in 1:length(mids)) {
+        annotations[[i]] = .AddXMLcenterBar(root, position=i, mid=mids[i],
+                                            count=counts[i], density=density[i],
+                                            start=breaks[i], end=breaks[i + 1])
+    }
+    .AddXMLaddComponents(annotation, annotations)
+    .AddXMLaddChildren(annotation, annotations)
+    .AddXMLaddParents(annotation, annotations)
+    annotation
+}
+
+
+.AddXMLcenterBar = function(root, position=1, mid=NULL, count=NULL, density=NULL, start=NULL, end=NULL) {
+    annotation = .AddXMLaddAnnotation(root, position=position,
+                                      id=.AddXMLmakeId("rect", paste("1.1", position, sep=".")),
+                                      kind="active")
+    XML::addAttributes(annotation$root,
+                       speech=paste("Bar", position, "at", mid, "with value", count),
+                       speech2=paste("Bar", position, "between x values", start,
+                                     "and", end, " with y value", count, "and density", density),
+                       type="Bar")
     annotation
 }
 

--- a/R/AddXMLInternal.R
+++ b/R/AddXMLInternal.R
@@ -1,34 +1,99 @@
-
+## Annotating axes
 .AddXMLaddXAxis = function(root, values=NULL, label="", groupPosition=2) {
-    position = 1
-    .AddXMLaddLabel(root, label=label, position=position, id="xlab", axis="xaxis")
+    .AddXMLaddAxis(root, values, label, groupPosition, "x axis", "xaxis", "xlab", "bottom")
 }
 
 .AddXMLaddYAxis = function(root, values=NULL, label="", groupPosition=3) {
-    position = 1
-    .AddXMLaddLabel(root, label=label, position=position, id="ylab", axis="yaxis")
+    .AddXMLaddAxis(root, values, label, groupPosition, "y axis", "yaxis", "ylab", "left")
+}
+
+.AddXMLaddAxis = function(root, values, label, groupPosition, name, groupId, labelId, lineId) {
+    position = 0
+    labelNode = .AddXMLaxisLabel(root, label=label, position=position <- position + 1,
+                     id=labelId, axis=groupId)
+    lineNode = .AddXMLaxisLine(root, id=lineId, axis=groupId)
+    tickNodes = .AddXMLaxisValues(root, values=values,
+                              position=position <- position + 1, id=lineId, axis=groupId)
+    annotations = c(list(labelNode, lineNode), tickNodes)
+    .AddXMLaxisGroup(root, groupId, name, values=values, label=label,
+                     annotations=annotations, position=groupPosition)
 }
 
 
-.AddXMLaddLabel = function(root, label="", position=1, id="", axis="") {
+## Aux method for axis group
+.AddXMLaxisGroup = function(root, id, name, values=NULL, label="", annotations=NULL, position=1) {
+    annotation = .AddXMLaddAnnotation(root, position=position, id=id, type="grouped")
+    clone <- function(x) .AddXMLclone(annotation$component, x$element)
+    lapply(annotations, clone)
+    print(label)
+    XML::addAttributes(annotation$root, speech=paste(name, label),
+                       speech2=paste(name, label, "with values from", values[1], "to", values[length(values)]),
+                       type="Axis")
+    annotation
+}
+
+## Aux methods for axes annotation.
+.AddXMLaxisLabel = function(root, label="", position=1, id="", axis="") {
     annotation = .AddXMLaddAnnotation(root, position=position,
-                                      id=paste("graphics-plot-1", id, "1.1", sep="-"), type="active")
+                                      id=.AddXMLmakeId(id, "1.1"), type="active")
     XML::addAttributes(annotation$root, speech=paste("Label", label), type="Label")
     if (axis != "") {
         .AddXMLaddNode(annotation$parents, "grouped", axis)
     }
-    annotation$root
+    annotation
+}
+
+.AddXMLaxisLine = function(root, position=1, id="", axis="") {
+    annotation = .AddXMLaddAnnotation(root, position=position,
+                                      id=.AddXMLmakeId(id, "line", "1.1"), type="passive")
+    XML::addAttributes(annotation$root, type="Line")
+    if (axis != "") {
+        .AddXMLaddNode(annotation$parents, "grouped", axis)
+    }
+    annotation
+}
+
+.AddXMLaxisValues = function(root, values=NULL, position=1, id="", axis="") {
+    annotations <- list()
+    for (i in 1:length(values)) {
+        valueId = .AddXMLmakeId(id, "axis", "labels", paste("1.1", i, sep="."))
+        value = .AddXMLaddAnnotation(root, position=position + i - 1,
+                                     id=valueId, type="active")
+        XML::addAttributes(value$root, speech=paste("Value", values[i]), type="Value")
+        
+        tickId = .AddXMLmakeId(id, "axis", "ticks", paste("1.1", i, sep="."))
+        tick = .AddXMLaddAnnotation(root, id=tickId, type="passive")
+        XML::addAttributes(tick$root, type="Tick")
+
+        .AddXMLaddNode(value$component, "passive", tickId)
+        .AddXMLaddNode(tick$component, "active", valueId)
+
+        if (axis != "") {
+            .AddXMLaddNode(value$parents, "grouped", axis)
+            .AddXMLaddNode(tick$parents, "grouped", axis)
+        }
+        annotations[[2 * i - 1]] = value
+        annotations[[2 * i]] = tick
+    }
+    annotations
+}
+
+
+.AddXMLmakeId = function(...) {
+    paste("graphics-plot-1", ..., sep="-")
 }
 
 .AddXMLaddAnnotation = function(root, position=1, id="", type="active") {
     annotation = .AddXMLaddNode(root, "annotation")
-    .AddXMLaddNode(annotation, type, id)
+    element = .AddXMLaddNode(annotation, type, id)
+    ## This should be changed!
     .AddXMLStoreComponent(id, type)
     list(root = annotation,
-          position = .AddXMLaddNode(annotation, "position", content=position),
-          parents = .AddXMLaddNode(annotation, "parents"),
-          component = .AddXMLaddNode(annotation, "component"),
-          neighbours = .AddXMLaddNode(annotation, "neighbours"))
+         element = element,
+         position = .AddXMLaddNode(annotation, "position", content=position),
+         parents = .AddXMLaddNode(annotation, "parents"),
+         component = .AddXMLaddNode(annotation, "component"),
+         neighbours = .AddXMLaddNode(annotation, "neighbours"))
 }
 
 
@@ -47,6 +112,15 @@
     newNode
 }
 
+# A shallow clone function for leaf nodes only. Avoids problems with duplicating
+# namespaces.
+.AddXMLclone = function(root, node) {
+    newNode = XML::newXMLNode(XML::xmlName(node, full=TRUE), parent = root)
+    XML::newXMLTextNode(XML::xmlValue(node), parent=newNode)
+    newNode
+}
+
+## Store components for top level Element
 .AddXMLActive = NULL
 .AddXMLPassive = NULL
 .AddXMLGrouped = NULL

--- a/R/AddXMLInternal.R
+++ b/R/AddXMLInternal.R
@@ -7,17 +7,26 @@
     root = XML::xmlRoot(doc)
     annotations = .AddXMLaddNode(root, "annotations")
 
-    title = .AddXMLaddTitle(annotations, title=diag$title)
+    main <- if (is.null(diag$main)) {paste("Histogram of", diag$xname)} else {diag$main}
+    xvalues <- diag$xTicks
+    yvalues <- diag$yTicks
+    title = .AddXMLaddTitle(annotations, title=main)
     
     xlab <- if (is.null(diag$xlab)) {diag$xname} else {diag$xlab}
     ylab <- if (is.null(diag$ylab)) {"Frequency"} else {diag$ylab}
-    xaxis = .AddXMLaddXAxis(annotations, label=xlab, values=diag$xTicks)
-    yaxis = .AddXMLaddYAxis(annotations, label=ylab, values=diag$yTicks)
+    xaxis = .AddXMLaddXAxis(annotations, label=xlab, values=xvalues)
+    yaxis = .AddXMLaddYAxis(annotations, label=ylab, values=yvalues)
     
-    ## That's probably the only one that is diagram dependent.
+    ## That's probably the part that is diagram dependent.
     center = .AddXMLaddHistogramCenter(
         annotations, mids=diag$mids, counts=diag$counts, density=diag$density, breaks=diag$breaks)
-    .AddXMLaddChart(annotations, type="Histogram", children=list(title, xaxis, yaxis, center))
+    values = 
+    .AddXMLaddChart(annotations, type="Histogram",
+                    speech=paste("Histogram of", xlab),
+                    speech2=paste("Histogram of", xlab, "with values from", xvalues[1],  "to",
+                                  xvalues[length(xvalues)], "and", ylab, "from", yvalues[1],  "to",
+                                  yvalues[length(xvalues)]),
+                    children=list(title, xaxis, yaxis, center))
     doc
 }
 
@@ -80,7 +89,7 @@
 ## Axis line
 .AddXMLaxisLine = function(root, position=1, id="", axis="") {
     annotation = .AddXMLaddAnnotation(root, position=position,
-                                      id=.AddXMLmakeId(id, "line", "1.1"), kind="passive")
+                                      id=.AddXMLmakeId(id, "axis", "line", "1.1"), kind="passive")
     XML::addAttributes(annotation$root, type="Line")
     annotation
 }

--- a/R/AddXMLInternal.R
+++ b/R/AddXMLInternal.R
@@ -1,12 +1,6 @@
 ## Annotating axes
-.AddXMLaddXAxis = function(root, values=NULL, label="", groupPosition=2) {
-    .AddXMLaddAxis(root, values, label, groupPosition, "x axis", "xaxis", "xlab", "bottom")
-}
-
-.AddXMLaddYAxis = function(root, values=NULL, label="", groupPosition=3) {
-    .AddXMLaddAxis(root, values, label, groupPosition, "y axis", "yaxis", "ylab", "left")
-}
-
+##
+## Generic axis annotation function.
 .AddXMLaddAxis = function(root, values, label, groupPosition, name, groupId, labelId, lineId) {
     position = 0
     labelNode = .AddXMLaxisLabel(root, label=label, position=position <- position + 1,
@@ -17,6 +11,16 @@
     annotations = c(list(labelNode, lineNode), tickNodes)
     .AddXMLaxisGroup(root, groupId, name, values=values, label=label,
                      annotations=annotations, position=groupPosition)
+}
+
+## Parameterisation for x-axis
+.AddXMLaddXAxis = function(root, values=NULL, label="", groupPosition=2) {
+    .AddXMLaddAxis(root, values, label, groupPosition, "x axis", "xaxis", "xlab", "bottom")
+}
+
+## Parameterisation for x-axis
+.AddXMLaddYAxis = function(root, values=NULL, label="", groupPosition=3) {
+    .AddXMLaddAxis(root, values, label, groupPosition, "y axis", "yaxis", "ylab", "left")
 }
 
 
@@ -32,7 +36,10 @@
     annotation
 }
 
+
 ## Aux methods for axes annotation.
+##
+## Axis labelling
 .AddXMLaxisLabel = function(root, label="", position=1, id="", axis="") {
     annotation = .AddXMLaddAnnotation(root, position=position,
                                       id=.AddXMLmakeId(id, "1.1"), type="active")
@@ -43,6 +50,7 @@
     annotation
 }
 
+## Axis line
 .AddXMLaxisLine = function(root, position=1, id="", axis="") {
     annotation = .AddXMLaddAnnotation(root, position=position,
                                       id=.AddXMLmakeId(id, "line", "1.1"), type="passive")
@@ -53,6 +61,7 @@
     annotation
 }
 
+## Axis values and ticks
 .AddXMLaxisValues = function(root, values=NULL, position=1, id="", axis="") {
     annotations <- list()
     for (i in 1:length(values)) {
@@ -79,10 +88,14 @@
 }
 
 
+## Auxiliary methods for annotations
+##
+## Construct a gridSVG id.
 .AddXMLmakeId = function(...) {
     paste("graphics-plot-1", ..., sep="-")
 }
 
+## Construct an SRE annotation element.
 .AddXMLaddAnnotation = function(root, position=1, id="", type="active") {
     annotation = .AddXMLaddNode(root, "annotation")
     element = .AddXMLaddNode(annotation, type, id)
@@ -96,7 +109,7 @@
          neighbours = .AddXMLaddNode(annotation, "neighbours"))
 }
 
-
+## Construct the basic XML annotation document.
 .AddXMLdocument = function(tag = "histogram") {
     doc = XML::newXMLDoc()
     top = XML::newXMLNode(tag, doc = doc)
@@ -104,12 +117,13 @@
     doc
 }
 
-.AddXMLaddNode = function(node, tag, content="") {
-    newNode = XML::newXMLNode(paste("sre:", tag, sep=""), parent = node)
+## Add a new node with tag name and optionally text content to the given root.
+.AddXMLaddNode = function(root, tag, content="") {
+    node = XML::newXMLNode(paste("sre:", tag, sep=""), parent = root)
     if (content != "") {
-        XML::newXMLTextNode(content, parent=newNode)
+        XML::newXMLTextNode(content, parent=node)
     }
-    newNode
+    node
 }
 
 # A shallow clone function for leaf nodes only. Avoids problems with duplicating

--- a/R/AddXMLInternal.R
+++ b/R/AddXMLInternal.R
@@ -7,8 +7,8 @@
     root = XML::xmlRoot(doc)
     annotations = .AddXMLaddNode(root, "annotations")
 
-    ## title = AddXMLaddTitle()
-
+    title = .AddXMLaddTitle(annotations, title=diag$title)
+    
     xlab <- if (is.null(diag$xlab)) {diag$xname} else {diag$xlab}
     ylab <- if (is.null(diag$ylab)) {"Frequency"} else {diag$ylab}
     xaxis = .AddXMLaddXAxis(annotations, label=xlab, values=diag$xTicks)
@@ -17,11 +17,16 @@
     ## That's probably the only one that is diagram dependent.
     center = .AddXMLaddHistogramCenter(
         annotations, mids=diag$mids, counts=diag$counts, density=diag$density, breaks=diag$breaks)
-    .AddXMLaddChart(annotations, type="Histogram", children=list(xaxis, yaxis, center))
+    .AddXMLaddChart(annotations, type="Histogram", children=list(title, xaxis, yaxis, center))
     doc
 }
 
 ## Annotating title elements
+.AddXMLaddTitle = function(root, title="") {
+    annotation = .AddXMLaddAnnotation(root, position=1, .AddXMLmakeId("main", "1.1"), kind="active")
+    XML::addAttributes(annotation$root, speech=paste("Title", title), type="Title")
+    annotation
+}
 
 ## Annotating axes
 ##
@@ -216,7 +221,6 @@
 .AddXMLaddChart = function(root, children=NULL, speech="", speech2="", type="") {
     annotation = .AddXMLaddAnnotation(root, id="chart", kind="grouped")
     XML::addAttributes(annotation$root, speech=speech, speech2=speech2, type=type)
-    print(.AddXMLcomponents)
     .AddXMLaddComponents(annotation, .AddXMLcomponents)
     .AddXMLaddChildren(annotation, children)
     .AddXMLaddParents(annotation, children)

--- a/R/AddXMLMethod.R
+++ b/R/AddXMLMethod.R
@@ -42,12 +42,14 @@ AddXML.ggplot = function(x, file) {
     XML::saveXML(doc=doc, file=file)
 }
 
-AddXML.histogram = function(x, file) {
+AddXML.histogram = function(diag, file) {
     doc = .AddXMLdocument("histogram")
     root = XML::xmlRoot(doc)
     annotations = .AddXMLaddNode(root, "annotations")
-    .AddXMLaddXAxis(annotations, label=x$xlab)
-    .AddXMLaddYAxis(annotations, label=x$ylab)
+    xlab <- if (is.null(diag$xlab)) {diag$xname} else {diag$xlab}
+    ylab <- if (is.null(diag$ylab)) {"Frequency"} else {diag$ylab}
+    .AddXMLaddXAxis(annotations, label=xlab, values=diag$xTicks)
+    .AddXMLaddYAxis(annotations, label=ylab, values=diag$yTicks)
     XML::saveXML(doc=doc, file=file)
 }
 

--- a/R/AddXMLMethod.R
+++ b/R/AddXMLMethod.R
@@ -43,13 +43,7 @@ AddXML.ggplot = function(x, file) {
 }
 
 AddXML.histogram = function(diag, file) {
-    doc = .AddXMLdocument("histogram")
-    root = XML::xmlRoot(doc)
-    annotations = .AddXMLaddNode(root, "annotations")
-    xlab <- if (is.null(diag$xlab)) {diag$xname} else {diag$xlab}
-    ylab <- if (is.null(diag$ylab)) {"Frequency"} else {diag$ylab}
-    .AddXMLaddXAxis(annotations, label=xlab, values=diag$xTicks)
-    .AddXMLaddYAxis(annotations, label=ylab, values=diag$yTicks)
+    doc = .AddXMLhistogram(diag)
     XML::saveXML(doc=doc, file=file)
 }
 


### PR DESCRIPTION
Adds the full generation of XML markup for histograms.
It effectively produces something very similar to the mockup for Ozone we had. 
In addition it now extracts the data straight from the model and gives textual description for bars on two layers.