### PR TITLE
Fix ggplot 3.0 x and y ticks fetching for VI.ggplot()

### DIFF
--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -46,18 +46,24 @@
 
 .getGGXTicks = function(x, xbuild, layer) {
   # The location of this item is changing in an upcoming ggplot version
-  if ("panel_ranges" %in% names(xbuild$layout))
+  if ("panel_ranges" %in% names(xbuild$layout)) {
     return(xbuild$layout$panel_ranges[[layer]]$x.labels)   # ggplot 2.2.1
-  else
-    return(xbuild$layout$panel_params[[layer]]$x.labels)   # dev version as at 5 Sept 2017
+  }
+  else {
+    xlabs <- xbuild$layout$panel_params[[1]]$x$get_labels()
+    return (xlabs[!is.na(xlabs)])
+  }
 }
 
 .getGGYTicks = function(x, xbuild, layer) {
   # The location of this item is changing in an upcoming ggplot version
-  if ("panel_ranges" %in% names(xbuild$layout))
+  if ("panel_ranges" %in% names(xbuild$layout)) {
     return(xbuild$layout$panel_ranges[[layer]]$y.labels)   # ggplot 2.2.1
-  else
-    return(xbuild$layout$panel_params[[layer]]$y.labels)   # dev version as at 5 Sept 2017
+  }
+  else {
+    ylabs <- xbuild$layout$panel_params[[1]]$y$get_labels()
+    return (ylabs[!is.na(ylabs)])
+  }
 }
 
 # Guides

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -14,7 +14,7 @@
       result[[i]] = character(0)
     } else {
       render = whisker::whisker.render(templates[names(x[i])], x[[i]], partials=templates)
-    result[[i]] = as.vector(strsplit(render, "<br>", fixed=TRUE)[[1]])
+      result[[i]] = as.vector(strsplit(render, "<br>", fixed=TRUE)[[1]])
     }
   }
   names(result) = names(x)
@@ -44,7 +44,7 @@
     x$xaxis$xtickitems = .listifyVars(list(label=x$xaxis$xticklabels))
   if (!is.null(x$yaxis$yticklabels))
     x$yaxis$ytickitems = .listifyVars(list(label=x$yaxis$yticklabels))
-  
+
   for (legendi in 1:length(x$legends)) {
     if (!is.null(x$legends[[legendi]]$scalelevels))
       x$legends[[legendi]]$scalelevelitems = 
@@ -168,49 +168,45 @@ sort.VIgraph <- function(x, decreasing = FALSE, by="x", ...) {
 }
 
 grep <- function(pattern, x, ...) {
-    ## Dispatch on 'x' rather than 'pattern' !!!
-    UseMethod("grep", x)
+  ## Dispatch on 'x' rather than 'pattern' !!!
+  UseMethod("grep", x)
 }
 
-grep.default <-
-    function(pattern, x, ignore.case = FALSE, perl = FALSE, value = FALSE,
-             fixed = FALSE, useBytes = FALSE, invert = FALSE, ...) {
-        base::grep(pattern, x, ignore.case, perl, value,
-                   fixed, useBytes, invert)
-    }
+grep.default <- function(pattern, x, ignore.case = FALSE, perl = FALSE, value = FALSE, fixed = FALSE, useBytes = FALSE, invert = FALSE, ...) {
+  base::grep(pattern, x, ignore.case, perl, value, fixed, useBytes, invert)
+}
 
 # Returns the VIgraph object with the text trimmed down to only those rows
 # containing the specified pattern.  Passes extra parameters on to grepl.
 # Note that only the text portion of the VIgraph is modified; the complete
 # VIgg structure is still included
 grep.VIgraph <- function(pattern, x, ...) {
-    x$text = grep(pattern, x$text, value=TRUE, ...)
-    x
+  x$text = grep(pattern, x$text, value=TRUE, ...)
+  x
 }
 
 gsub <- function(pattern, replacement, x, ...) {
-    ## Dispatch on 'x' rather than 'pattern' !!!
-    UseMethod("gsub", x)
+  ## Dispatch on 'x' rather than 'pattern' !!!
+  UseMethod("gsub", x)
 }
-  
+
 gsub.default <-
-    function(pattern, replacement, x,
-             ignore.case = FALSE, perl = FALSE,
-             fixed = FALSE, useBytes = FALSE, ...) {
-        base::gsub(pattern, replacement, x, ignore.case, perl, 
-                   fixed, useBytes)
-    }
+  function(pattern, replacement, x,
+           ignore.case = FALSE, perl = FALSE,
+           fixed = FALSE, useBytes = FALSE, ...) {
+    base::gsub(pattern, replacement, x, ignore.case, perl, 
+               fixed, useBytes)
+  }
 
 gsub.VIgraph <- function(pattern, replacement, x, ...) {
-    x$text = gsub(pattern, replacement, x$text, ...)
-    x
+  x$text = gsub(pattern, replacement, x$text, ...)
+  x
 }
 
 # threshold specifies how many points, lines, etc will be explicitly listed.
 # Greater numbers will be summarised (e.g. "is a set of 32 horizontal lines" vs
 # "is a set of 3 horizontal lines at 5, 7.5, 10")
-VI.ggplot = function(x, Describe=FALSE, threshold=10, 
-                     template=system.file("whisker/VIdefault.txt", package="BrailleR"), ...) {
+VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whisker/VIdefault.txt", package="BrailleR"), ...) {
   VIstruct = .VIstruct.ggplot(x)
   text = .VItextify(list(VIgg=.VIpreprocess(VIstruct, threshold)), template)[[1]]
   VIgraph = list(VIgg=VIstruct, text=text, threshold=threshold, template=template)
@@ -249,7 +245,7 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
   panelcols = as.list(.getGGFacetCols(x, xbuild))
   layerCount = .getGGLayerCount(x, xbuild);
   VIstruct = .VIlist(annotations=annotations, xaxis=xaxis, yaxis=yaxis, legends=legends, panels=panels,
-              npanels=length(panels), nlayers=layerCount, panelrows=panelrows, panelcols=panelcols, type="ggplot")
+                     npanels=length(panels), nlayers=layerCount, panelrows=panelrows, panelcols=panelcols, type="ggplot")
   class(VIstruct) = "VIstruct"
   return(VIstruct)
 }
@@ -266,7 +262,7 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
     ## From ggplot2 3.0.0 can have x$labels without any corresponding
     ## xbuild$plot$scales
     if (is.null(scale))
-        break;
+      break;
     scalediscrete = if ("ScaleDiscrete" %in% class(scale)) TRUE
     hidden = if (.isGuideHidden(x, xbuild, name)) TRUE
     maplevels = data.frame(col1=scale$map(scale$range$range), stringsAsFactors=FALSE)
@@ -311,12 +307,12 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
       panel[["yticklabels"]] = .getGGYTicks(x, xbuild, i)
       panel[["xlabel"]] = .getGGXLab(x, xbuild) # Won't actually change over the panels
       panel[["ylabel"]] = .getGGYLab(x, xbuild) # But we still want to mention them
-      
+
     }
     vars = list()
-      for (j in seq_along(panelvars)) {
-        vars[[j]] = list(varname=as.character(panelvars[j]), value=as.character(f[[i, panelvars[j]]]))
-      }
+    for (j in seq_along(panelvars)) {
+      vars[[j]] = list(varname=as.character(panelvars[j]), value=as.character(f[[i, panelvars[j]]]))
+    }
     panel[["vars"]] = vars
     panel[["panellayers"]] = .buildLayers(x, xbuild, i)
     panels[[i]] = panel
@@ -336,7 +332,7 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
     else
       ngroups = 1
     layerClass = .getGGLayerType(x, xbuild, layeri)
-    
+
     # HLINE
     if (layerClass == "GeomHline") {
       layer$type = "hline"
@@ -352,8 +348,8 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
       layer$scaledata = map$value
       # Also report on any aesthetic variables that vary across the layer
       layer = .addAesVars(x, xbuild, cleandata, layeri, layer, panel)
-      
-    # POINT
+
+      # POINT
     } else if (layerClass == "GeomPoint") {
       layer$type = "point"
       # Mark as hidden points that go outside the bounds of the plot,
@@ -369,7 +365,7 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
       layer$scaledata = map$value
       # Also report on any aesthetic variables that vary across the layer
       layer = .addAesVars(x, xbuild, cleandata, layeri, layer, panel)
-      
+
 
       # BAR
     } else if (layerClass == "GeomBar") {
@@ -392,8 +388,8 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
         layer$scaledata = cbind(layer$scaledata, xmin=cleandata$xmin, xmax=cleandata$xmax)
       # Also report on any aesthetic variables that vary across the layer
       layer = .addAesVars(x, xbuild, cleandata, layeri, layer, panel)
-      
-    # LINE
+
+      # LINE
     } else if (layerClass == "GeomLine") {
       layer$type = "line"
       # Lines are funny - each item in the data is a point
@@ -423,17 +419,17 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
         line = .addLineAesVars(x, xbuild, line, layeri, groupdata, panel)
         layer$lines[[length(layer$lines) + 1]] = line
       }
-      
-    #BOXPLOT
+
+      #BOXPLOT
     } else if (layerClass == "GeomBoxplot") {
       layer$type = "box"
       cleandata = layer$data   # No need for cleaning since this data is already aggregated
       layer$n = nrow(layer$data)
       nOutliers = sapply(cleandata$outliers,length)
       map = .mapDataValues(x, xbuild,list("x", "ymin", "lower", "middle", "upper", "ymax"), panel,
-                          list(x=cleandata$x, ymin=cleandata$ymin, lower=cleandata$lower, 
-                               middle=cleandata$middle, upper=cleandata$upper, 
-                               ymax=cleandata$ymax))
+                           list(x=cleandata$x, ymin=cleandata$ymin, lower=cleandata$lower, 
+                                middle=cleandata$middle, upper=cleandata$upper, 
+                                ymax=cleandata$ymax))
       if (!is.null(map$badTransform)) {
         layer$badtransform = TRUE
         layer$transform = map$badTransform
@@ -445,17 +441,17 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
       # scaledata is currently a list of vectors.  If we wanted to include outliers
       # within each boxes object for reporting, then boxes would need to become
       # a list of lists.
-      
+
       # Also report on any aesthetic variables that vary across the layer
       layer = .addAesVars(x, xbuild, cleandata, layeri, layer, panel)
-      
-    # SMOOTH
+
+      # SMOOTH
     } else if (layerClass == "GeomSmooth") {
       layer$type = "smooth"
       layer$method = .getGGSmoothMethod(x, xbuild, layeri)
       layer$ci = if (.getGGSmoothSEflag(x, xbuild, layeri)) TRUE
-      
-    #U UNKNOWN
+
+      #U UNKNOWN
     } else {
       layer$type = "unknown"
     }
@@ -469,7 +465,7 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
   for (var in varlist) {
     value = valuelist[[var]]
     scale = .getGGScale(x, xbuild, var)
-    
+
     if (is.null(scale))   # No scale found
       next
     else if (("ScaleDiscrete" %in% class(scale))) { # Try to map back to levels
@@ -559,7 +555,7 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10,
   ## Use unconverted aesthetics for reverse lookup of mappings
   ## groupdata[1,aesvars,drop=FALSE] rather than aesvals[1,,drop=FALSE]
   aesmap = .mapAesDataValues(x, xbuild, layeri, aesvars,
-                            groupdata[1,aesvars,drop=FALSE])
+                             groupdata[1,aesvars,drop=FALSE])
   line[aesvars] = aesvals
   if (length(aesmap) > 0) {
     names(aesmap) = paste0(names(aesmap), "map")


### PR DESCRIPTION
This PR:

- Fixes a few indentation issues in the code (standardised to 2 spaces per tab char)
- Fixes the `.getGGXticks` and `.getGGYTicks` function to retrieve correct tick labels for ggplot 3.0+ charts

Hopefully this will allow the package to be back on CRAN. Kudos for the great work! 💯 

It might be a good idea to standardise on a linter for R, to maintain code quality. I also think it would be a good idea to add tests for these functions, and while I did find a `tests/` directory, I couldn't find any instructions to change this. Are these ideas you'd be open to explore? I could do some research if that's the case.

Fixes #25 