### PR TITLE
Shaded area for Geom_smooth

### DIFF
--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -314,4 +314,29 @@
   return(AnA)
 }
 
+.getGGShadedArea = function(x, xbuild, layer) {
+  data = xbuild$data[[layer]]
+  
+  #Width of the shaded area
+  width = data$ymax - data$ymin
+  
+  #Get the length of each shaded area
+  #I believe they might be constant
+  x_values = sort(data$x)
+  distances = rep(0, length(x_values))
+  for (i in 1:(length(x_values)-1)) {
+    distances[i] = x_values[i+1]-x_values[i]
+  }
+  
+  #Length of x and y axis
+  xaxis = xbuild$layout$panel_scales_x[[1]]$range$range
+  yaxis = xbuild$layout$panel_scales_y[[1]]$range$range
+  
+  #Calculate area approximations
+  shadedArea = sum(abs(distances) * abs(width))
+  totalArea = (xaxis[2] - xaxis[1]) * (yaxis[2] - yaxis[1])
+  
+  #Return percent
+  return(shadedArea / totalArea )
+}
 

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -460,13 +460,22 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       layer$type = "ribbon"
       data = xbuild$data[[layeri]]
       
+      widthIntervals = seq(from=1, to=length(data$y), length.out=5)
+      layer$intervalPoints = data$x[widthIntervals] |> paste(collapse=", ")
+      
       #Width of the ribbon
       yMin = data$ymin
       yMax = data$ymax
-      if (is.null(yMin) && is.null(yMax)) {
+      
+      width = yMax-yMin
+      
+      if (is.null(yMin) && is.null(yMax)) { #No bounds
         layer$noybounds = T
-      } else {
-        layer$ribbonwidth = mean(yMax-yMin)
+      } else if (mean(width) != width[1]) { #Non constant bounds
+        layer$nonconstantribbonwidth = T
+        layer$ribbonwidth = width[widthIntervals] |> signif()  |> paste(collapse=", ")
+      } else { #Constant bounds
+        layer$ribbonwidth = width[1]
       }
       
       #Length of the ribbon
@@ -477,6 +486,15 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       } else {
         layer$ribbonlength = mean(abs(xMax-xMin))
       }
+      
+      #Shape of ribbon
+      # Only showing the shape when there is y bounds
+      if (!is.null(data$ymin) || is.null(data$ymax)) { #Has min and max
+        layer$centre = (yMax + yMin)[widthIntervals] |>
+          map(~ signif((.x / 2)) ) |>
+          paste(collapse=", ")
+      }
+
       
       #U UNKNOWN
     } else {

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -455,7 +455,7 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       deci = toString(.getGGSmoothLevel(x, xbuild, layeri)*100)
       layer$level = paste(deci, "%", sep = "")
       
-      #Ribbon
+      #RIBBON
     } else if (layerClass == "GeomRibbon") {
       layer$type = "ribbon"
       data = xbuild$data[[layeri]]
@@ -468,31 +468,40 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       yMax = data$ymax
       
       width = yMax-yMin
-      
       if (is.null(yMin) && is.null(yMax)) { #No bounds
         layer$noybounds = T
-      } else if (mean(width) != width[1]) { #Non constant bounds
+      } else if (length(unique(width)) != 1) { #Non constant width
         layer$nonconstantribbonwidth = T
         layer$ribbonwidth = width[widthIntervals] |> signif()  |> paste(collapse=", ")
-      } else { #Constant bounds
+      } else { #Constant width
         layer$ribbonwidth = width[1]
       }
       
       #Length of the ribbon
       xMin = data$xmin
       xMax = data$xmax
+      length = abs(xMin - xMax)
       if ((is.null(xMin) && is.null(xMax)) || !is.null(layer$ribbonwidth)){
         layer$noxbounds = T
+      } else if (length(unique(length)) != 1) { #Non constant length
+        layer$nonconstantribbonlength = T
+        layer$ribbonlength = length[widthIntervals] |> signif()  |> paste(collapse=", ")
       } else {
         layer$ribbonlength = mean(abs(xMax-xMin))
       }
       
       #Shape of ribbon
-      # Only showing the shape when there is y bounds
+      # Only showing the shape info when there is y bounds
       if (!is.null(data$ymin) || is.null(data$ymax)) { #Has min and max
-        layer$centre = (yMax + yMin)[widthIntervals] |>
-          map(~ signif((.x / 2)) ) |>
-          paste(collapse=", ")
+        centres = (yMax + yMin)[widthIntervals] |>
+          map(~ signif((.x / 2)) )
+        if (length(unique(centres)) == 1) { # Centre is constant
+          layer$constantcentre = T
+          layer$centre = centres[1]
+        } else { #Centre non constant turn into string
+          layer$centre = centres |>
+            paste(collapse=", ")
+        }
       }
 
       

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -455,6 +455,14 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       deci = toString(.getGGSmoothLevel(x, xbuild, layeri)*100)
       layer$level = paste(deci, "%", sep = "")
       
+      if (.getGGSmoothSEflag(x, xbuild, layeri)) {
+        shadedproportion = .getGGShadedArea(x, xbuild, layeri)*100
+        layer$shadedarea = shadedproportion |>
+          round( 2) |>
+          toString() |>
+          paste("%", sep="")
+      }
+      
       #RIBBON
     } else if (layerClass == "GeomRibbon") {
       layer$type = "ribbon"

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -454,7 +454,30 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       #adding confidence level as a percentage
       deci = toString(.getGGSmoothLevel(x, xbuild, layeri)*100)
       layer$level = paste(deci, "%", sep = "")
-
+      
+      #Ribbon
+    } else if (layerClass == "GeomRibbon") {
+      layer$type = "ribbon"
+      data = xbuild$data[[layeri]]
+      
+      #Width of the ribbon
+      yMin = data$ymin
+      yMax = data$ymax
+      if (is.null(yMin) && is.null(yMax)) {
+        layer$noybounds = T
+      } else {
+        layer$ribbonwidth = mean(yMax-yMin)
+      }
+      
+      #Length of the ribbon
+      xMin = data$xmin
+      xMax = data$xmax
+      if ((is.null(xMin) && is.null(xMax)) || !is.null(layer$ribbonwidth)){
+        layer$noxbounds = T
+      } else {
+        layer$ribbonlength = mean(abs(xMax-xMin))
+      }
+      
       #U UNKNOWN
     } else {
       layer$type = "unknown"

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -140,11 +140,11 @@ There are {{noutliers}} outliers for this boxplot.<br>
 a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals{{/ci}}.
 {{/typesmooth}}
 {{#typeribbon}}
-a ribbon around the data 
+a ribbon 
 {{^noybounds}}
-{{^nonconstantribbonwidth}}with a constant width of {{ribbonwidth}}. At these five x values: {{intervalPoints}} the center of ribbon is{{/nonconstantribbonwidth}}
-{{#nonconstantribbonwidth}}with non constant width at these points on x axis: {{intervalPoints}} it was this wide: {{ribbonwidth}} with center at{{/nonconstantribbonwidth}}
-: {{centre}}.{{/noybounds}}
+{{^nonconstantribbonwidth}}with a constant width of {{ribbonwidth}}. The center of the ribbon is{{/nonconstantribbonwidth}}
+{{#nonconstantribbonwidth}}with non constant width it was this wide: {{ribbonwidth}} with center at{{/nonconstantribbonwidth}}
+{{#constantcentre}} constant{{/constantcentre}}: {{centre}}.{{/noybounds}}
 {{#noybounds}}with no y bounds covering entire y range.{{/noybounds}}
 {{^noxbounds}} It has a length of {{ribbonlength}}{{/noxbounds}}
 {{#noxbounds}} It spans the whole of the x range{{/noxbounds}}. <br>

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -142,11 +142,11 @@ a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals{{/ci}}.
 {{#typeribbon}}
 a ribbon 
 {{^noybounds}}
-{{^nonconstantribbonwidth}}with a constant width of {{ribbonwidth}}. The center of the ribbon is{{/nonconstantribbonwidth}}
-{{#nonconstantribbonwidth}}with non constant width it was this wide: {{ribbonwidth}} with center at{{/nonconstantribbonwidth}}
+{{^nonconstantribbonwidth}}with a constant width of {{ribbonwidth}} and centers are{{/nonconstantribbonwidth}}
+{{#nonconstantribbonwidth}}with non constant widths: {{ribbonwidth}} and centers at{{/nonconstantribbonwidth}}
 {{#constantcentre}} constant{{/constantcentre}}: {{centre}}.{{/noybounds}}
 {{#noybounds}}with no y bounds covering entire y range.{{/noybounds}}
-{{^noxbounds}}{{^nonconstantribbonlength}} It has a constant length of{{/nonconstantribbonlength}}{{#nonconstantribbonlength}} It has a non constant lengths of{{/nonconstantribbonlength}}: {{ribbonlength}}.{{/noxbounds}}
+{{^noxbounds}} It has{{^nonconstantribbonlength}} a constant length{{/nonconstantribbonlength}}{{#nonconstantribbonlength}} non constant lengths{{/nonconstantribbonlength}} of: {{ribbonlength}}.{{/noxbounds}}
 <br>
 {{/typeribbon}}
 {{#typeunknown}}

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -140,8 +140,14 @@ There are {{noutliers}} outliers for this boxplot.<br>
 a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals{{/ci}}.
 {{/typesmooth}}
 {{#typeribbon}}
-a ribbon around the data {{^noybounds}}with a average width of {{ribbonwidth}}{{/noybounds}}{{#noybounds}}with no y bounds covering entire y range{{/noybounds}}. 
-{{^noxbounds}}It has a length of {{ribbonlength}}{{/noxbounds}}{{#noxbounds}}It spans the whole of the x range{{/noxbounds}}.<br>
+a ribbon around the data 
+{{^noybounds}}
+{{^nonconstantribbonwidth}}with a constant width of {{ribbonwidth}}. At these five x values: {{intervalPoints}} the center of ribbon is{{/nonconstantribbonwidth}}
+{{#nonconstantribbonwidth}}with non constant width at these points on x axis: {{intervalPoints}} it was this wide: {{ribbonwidth}} with center at{{/nonconstantribbonwidth}}
+: {{centre}}.{{/noybounds}}
+{{#noybounds}}with no y bounds covering entire y range.{{/noybounds}}
+{{^noxbounds}} It has a length of {{ribbonlength}}{{/noxbounds}}
+{{#noxbounds}} It spans the whole of the x range{{/noxbounds}}. <br>
 {{/typeribbon}}
 {{#typeunknown}}
 {{anA}} {{assign}} graph that VI can not process.<br>

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -137,7 +137,7 @@ There are {{noutliers}} outliers for this boxplot.<br>
 {{/items}}
 {{/typebox}}
 {{#typesmooth}}
-a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals{{/ci}}.
+a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals{{/ci}}.{{#shadedarea}} The CI shaded area takes up {{shadedarea}} of graph.{{/shadedarea}}
 {{/typesmooth}}
 {{#typeribbon}}
 a ribbon 

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -139,6 +139,10 @@ There are {{noutliers}} outliers for this boxplot.<br>
 {{#typesmooth}}
 a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals{{/ci}}.
 {{/typesmooth}}
+{{#typeribbon}}
+a ribbon around the data {{^noybounds}}with a average width of {{ribbonwidth}}{{/noybounds}}{{#noybounds}}with no y bounds covering entire y range{{/noybounds}}. 
+{{^noxbounds}}It has a length of {{ribbonlength}}{{/noxbounds}}{{#noxbounds}}It spans the whole of the x range{{/noxbounds}}.<br>
+{{/typeribbon}}
 {{#typeunknown}}
 {{anA}} {{assign}} graph that VI can not process.<br>
 {{/typeunknown}}

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -146,8 +146,8 @@ a ribbon
 {{#nonconstantribbonwidth}}with non constant width it was this wide: {{ribbonwidth}} with center at{{/nonconstantribbonwidth}}
 {{#constantcentre}} constant{{/constantcentre}}: {{centre}}.{{/noybounds}}
 {{#noybounds}}with no y bounds covering entire y range.{{/noybounds}}
-{{^noxbounds}} It has a length of {{ribbonlength}}{{/noxbounds}}
-{{#noxbounds}} It spans the whole of the x range{{/noxbounds}}. <br>
+{{^noxbounds}}{{^nonconstantribbonlength}} It has a constant length of{{/nonconstantribbonlength}}{{#nonconstantribbonlength}} It has a non constant lengths of{{/nonconstantribbonlength}}: {{ribbonlength}}.{{/noxbounds}}
+<br>
 {{/typeribbon}}
 {{#typeunknown}}
 {{anA}} {{assign}} graph that VI can not process.<br>


### PR DESCRIPTION
It now works for geom_smooth.

The created method could theoretically be used with any geom that has min and max. However it has no guarantee of efficiency and constant runtime outside of geom_smooth().