### PR TITLE
0.33.4 Add shaded area percent to geom_smooth VI summary.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+#BrailleR 0.33.4
+-Add shaded area for geom_smooth CI info to VI output.
+
 # BrailleR 0.33.3
 -Update author files
 -Change the VI.ggplot output for unrecognized graphs to correct spelling of cannot

--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -315,3 +315,28 @@
 }
 
 
+.getGGShadedArea = function(x, xbuild, layer) {
+  data = xbuild$data[[layer]]
+  
+  #Width of the shaded area
+  width = data$ymax - data$ymin
+  
+  #Get the length of each shaded area
+  #I believe they might be constant
+  x_values = sort(data$x)
+  distances = rep(0, length(x_values))
+  for (i in 1:(length(x_values)-1)) {
+    distances[i] = x_values[i+1]-x_values[i]
+  }
+  
+  #Length of x and y axis
+  xaxis = xbuild$layout$panel_scales_x[[1]]$range$range
+  yaxis = xbuild$layout$panel_scales_y[[1]]$range$range
+  
+  #Calculate area approximations
+  shadedArea = sum(abs(distances) * abs(width))
+  totalArea = (xaxis[2] - xaxis[1]) * (yaxis[2] - yaxis[1])
+  
+  #Return percent
+  return(shadedArea / totalArea )
+}

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -454,6 +454,14 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       #adding confidence level as a percentage
       deci = toString(.getGGSmoothLevel(x, xbuild, layeri)*100)
       layer$level = paste(deci, "%", sep = "")
+      
+      if (layer$ci) {
+        shadedproportion = .getGGShadedArea(x, xbuild, layeri)*100
+        layer$shadedarea = shadedproportion |>
+          signif(2) |>
+          toString() |>
+          paste("%", sep="")
+      }
 
       #U UNKNOWN
     } else {

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -137,7 +137,7 @@ There are {{noutliers}} outliers for this boxplot.<br>
 {{/items}}
 {{/typebox}}
 {{#typesmooth}}
-a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals{{/ci}}.
+a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals covering {{shadedarea}} of the graph{{/ci}}.
 {{/typesmooth}}
 {{#typeunknown}}
 {{anA}} {{assign}} graph that VI cannot process.<br>


### PR DESCRIPTION
Give some information about how much space the shaded CI takes up.

For example this graph:
```
set.seed(2022)
x = rnorm(1e4)
y = rnorm(1e4,x, 10)
g <- ggplot(data.frame(x, y), aes(x, y)) +
  geom_smooth()
g
```
Would produce output like this:

> This is an untitled chart with no subtitle or caption.
It has x-axis 'x' with labels -4, -2, 0, 2 and 4.
It has y-axis 'y' with labels -2.5, 0.0, 2.5 and 5.0.
The chart is a 'lowess' smoothed curve with 95% confidence intervals covering 14% of the graph.