### PR TITLE
0.33.4 Add geom ribbon support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+#BrailleR 0.33.4
+-Add shaded area for geom_smooth CI info to VI output.
+
 # BrailleR 0.33.3
 -Update author files
 -Change the VI.ggplot output for unrecognized graphs to correct spelling of cannot

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 #BrailleR 0.33.4
 -Add shaded area for geom_smooth CI info to VI output.
+-Add geom_ribbon support
 
 # BrailleR 0.33.3
 -Update author files

--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -315,3 +315,28 @@
 }
 
 
+.getGGShadedArea = function(x, xbuild, layer) {
+  data = xbuild$data[[layer]]
+  
+  #Width of the shaded area
+  width = data$ymax - data$ymin
+  
+  #Get the length of each shaded area
+  #I believe they might be constant
+  x_values = sort(data$x)
+  distances = rep(0, length(x_values))
+  for (i in 1:(length(x_values)-1)) {
+    distances[i] = x_values[i+1]-x_values[i]
+  }
+  
+  #Length of x and y axis
+  xaxis = xbuild$layout$panel_scales_x[[1]]$range$range
+  yaxis = xbuild$layout$panel_scales_y[[1]]$range$range
+  
+  #Calculate area approximations
+  shadedArea = sum(abs(distances) * abs(width))
+  totalArea = (xaxis[2] - xaxis[1]) * (yaxis[2] - yaxis[1])
+  
+  #Return percent
+  return(shadedArea / totalArea )
+}

--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -315,18 +315,26 @@
 }
 
 
-.getGGShadedArea = function(x, xbuild, layer) {
+#Get the area which is filled in by the ymin and ymax found in the layer.
+#Useful for geomRibbon and geomSmooth
+.getGGShadedArea = function(x, xbuild, layer, useX = TRUE) {
   data = xbuild$data[[layer]]
   
   #Width of the shaded area
-  width = data$ymax - data$ymin
-  
+  if (useX) {
+    width = data$ymax - data$ymin
+    axis_values = sort(data$x)
+  } else {
+    width = data$xmax - data$xmin
+    axis_values = sort(data$y)
+  }
   #Get the length of each shaded area
   #I believe they might be constant
-  x_values = sort(data$x)
-  distances = rep(0, length(x_values))
-  for (i in 1:(length(x_values)-1)) {
-    distances[i] = x_values[i+1]-x_values[i]
+  
+  
+  distances = rep(0, length(axis_values))
+  for (i in 1:(length(axis_values)-1)) {
+    distances[i] = axis_values[i+1]-axis_values[i]
   }
   
   #Length of x and y axis
@@ -337,6 +345,13 @@
   shadedArea = sum(abs(distances) * abs(width))
   totalArea = (xaxis[2] - xaxis[1]) * (yaxis[2] - yaxis[1])
   
-  #Return percent
-  return(shadedArea / totalArea )
+  #Get percentage
+  areaProportion = shadedArea / totalArea
+  areaPercentageStr = (areaProportion*100) |>
+    signif(2) |>
+    toString() |>
+    paste("%", sep="")
+  
+  
+  return(areaPercentageStr)
 }

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -454,6 +454,14 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       #adding confidence level as a percentage
       deci = toString(.getGGSmoothLevel(x, xbuild, layeri)*100)
       layer$level = paste(deci, "%", sep = "")
+      
+      if (layer$ci) {
+        shadedproportion = .getGGShadedArea(x, xbuild, layeri)*100
+        layer$shadedarea = shadedproportion |>
+          signif(2) |>
+          toString() |>
+          paste("%", sep="")
+      }
 
       #U UNKNOWN
     } else {

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -137,7 +137,7 @@ There are {{noutliers}} outliers for this boxplot.<br>
 {{/items}}
 {{/typebox}}
 {{#typesmooth}}
-a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals{{/ci}}.
+a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals covering {{shadedarea}} of the graph{{/ci}}.
 {{/typesmooth}}
 {{#typeunknown}}
 {{anA}} {{assign}} graph that VI cannot process.<br>

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -139,6 +139,11 @@ There are {{noutliers}} outliers for this boxplot.<br>
 {{#typesmooth}}
 a '{{method}}' smoothed curve{{#ci}} with {{level}} confidence intervals covering {{shadedarea}} of the graph{{/ci}}.
 {{/typesmooth}}
+{{#typeribbon}}
+a ribbon which is bound on the {{bound}} axis, with {{^nonconstantribbonwidth}}a constant width of {{#ribbonwidth}}{{value}}{{sep}}{{/ribbonwidth}} and centers are{{/nonconstantribbonwidth}}
+{{#nonconstantribbonwidth}}non constant widths: {{#ribbonwidth}}{{value}}{{sep}}{{/ribbonwidth}} with centers at{{/nonconstantribbonwidth}}{{#constantcentre}} constant{{/constantcentre}}: {{#centre}}{{value}}{{sep}}{{/centre}}. The ribbon takes up {{shadedarea}} of the graph.
+<br>
+{{/typeribbon}}
 {{#typeunknown}}
 {{anA}} {{assign}} graph that VI cannot process.<br>
 {{/typeunknown}}


### PR DESCRIPTION
Add geom ribbon support to the VI.ggplot command.
This is branched off the previous PR #52 

This will give information on the width and centre of the ribbon. As well as an area as percent of graph number.

For example these graphs:
```
d <- data.frame(year = 1875:1972, level = LakeHuron)
g2 <- ggplot(d, aes(x = year, y = level)) +
  geom_ribbon(aes(ymin = level - 1 * (year-1874)*0.01, ymax = level + 1 * (year-1874)*0.01)) + 
  geom_line()
g2
g3 <- ggplot(d, aes(x = year, y = level)) +
  geom_ribbon(aes(xmin= year-10 * level *0.01, xmax = year+10), fill="grey10") +
  geom_line()
g3
```

would produce these outputs:

> This is an untitled chart with no subtitle or caption.
It has x-axis 'year' with labels 1850, 1900 and 1950.
It has y-axis 'level' with labels 576, 578, 580 and 582.
It has 2 layers.
Layer 1 is a ribbon which is bound on the x axis, with non constant widths: 67.6, 67.81, 67.91, 67.98 and 68.19 with centers at: 1940.2, 1926.09, 1936.04, 1881.01 and 1851.91. The ribbon takes up 41% of the graph.
Layer 1 has fill set to black.
Layer 2 is a set of 1 line.
Line 1 connects 98 points.

> This is an untitled chart with no subtitle or caption.
> It has x-axis 'year' with labels 1890, 1920 and 1950.
> It has y-axis 'level' with labels 576, 578, 580 and 582.
> It has 2 layers.
> Layer 1 is a ribbon which is bound on the x axis, with a constant width of 50 and centers are constant: 1895. The ribbon takes up 49% of the graph.
> Layer 1 has fill set to black.
> Layer 2 is a set of 1 line.
> Line 1 connects 98 points.