### PR TITLE
0.33.4 Add goem_area support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 #BrailleR 0.33.4
 -Add shaded area for geom_smooth CI info to VI output.
 -Add geom_ribbon support
+-Add geom_area support. This has been added to the geom_ribbon branch and is treated like a geom_ribbon almost exactly the same.
 
 # BrailleR 0.33.3
 -Update author files

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -460,18 +460,34 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       }
     
       #RIBBON
-    } else if (layerClass == "GeomRibbon") {
+    } else if (layerClass == "GeomRibbon" | layerClass =="GeomArea") {
       layer$type = "ribbon"
       data = xbuild$data[[layeri]]
       
-      widthIntervals = seq(from=1, to=length(data$y), length.out=5)
       
       #Width of the ribbon
       yMin = data$ymin
       yMax = data$ymax
       
+      #Length of the ribbon
       xMin = data$xmin
       xMax = data$xmax
+      
+      #actual data
+      x_data = data$x
+      y_data = data$y
+      
+      #Removing the leading and trailing 0
+      if(layerClass == "GeomArea") {
+        yMin = yMin[2:(length(yMin)-1)]
+        yMax = yMax[2:(length(yMax)-1)]
+        xMin = xMin[2:(length(xMin)-1)]
+        xMax = xMax[2:(length(xMax)-1)]
+        x_data = x_data[2:(length(x_data)-1)]
+        y_data = y_data[2:(length(y_data)-1)]
+      }
+      
+      widthIntervals = seq(from=1, to=length(y_data), length.out=5)
       
       #Bound on the x or y axis
       if (is.null(yMin) && is.null(yMax) && !is.null(xMin) && !is.null(xMax)) {
@@ -520,8 +536,7 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       } else {
         layer$shadedarea = .getGGShadedArea(x, xbuild, layeri, useX=F)
       }
-      
-      
+    
       #U UNKNOWN
     } else {
       layer$type = "unknown"


### PR DESCRIPTION
Add support for geom_area.

As it is just s special case of geom_area it is treated as such.

This graph
```
data("LakeHuron")
huron <- data.frame(year = 1875:1972, level = as.vector(LakeHuron))
area = ggplot(huron, aes(x=year, y=level)) +
  geom_area(aes(y=level))
area
```

Produces this VI explanation:

> This is an untitled chart with no subtitle or caption.
It has x-axis 'year' with labels 1875, 1900, 1925, 1950 and 1975.
It has y-axis 'level' with labels 0, 200, 400 and 600.
The chart is a ribbon which is bound on the y axis, with non constant widths: 580.38, 579.35, 578.02, 579.13 and 579.96 with centers at: 290.19, 289.68, 289.01, 289.56 and 289.98. The ribbon takes up 99% of the graph.

It doesn't summarise the widths or centers if they are similar as this example. This could be added to both geom_ribbon and geom_area.