### PR TITLE
0.33.4 Add expand_limits support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 -Add shaded area for geom_smooth CI info to VI output.
 -Add geom_ribbon support
 -Add geom_area support. This has been added to the geom_ribbon branch and is treated like a geom_ribbon almost exactly the same.
+-Add support for showing expand_limit effect on graph.
 
 # BrailleR 0.33.3
 -Update author files

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -144,6 +144,13 @@ a ribbon which is bound on the {{bound}} axis, with {{^nonconstantribbonwidth}}a
 {{#nonconstantribbonwidth}}non constant widths: {{#ribbonwidth}}{{value}}{{sep}}{{/ribbonwidth}} with centers at{{/nonconstantribbonwidth}}{{#constantcentre}} constant{{/constantcentre}}: {{#centre}}{{value}}{{sep}}{{/centre}}. The ribbon takes up {{shadedarea}} of the graph.
 <br>
 {{/typeribbon}}
+{{#typeexpand_limits}}
+a expand limits
+{{#xIncrease}}, increasing x axis by {{xIncrease}}{{/xIncrease}}
+{{#yIncrease}},{{#xIncrease}} and{{/xIncrease}} increasing y axis by {{yIncrease}}{{/yIncrease}}
+{{^xIncrease}}{{^yIncrease}} which has no effect{{/yIncrease}}{{/xIncrease}}
+.
+{{/typeexpand_limits}}
 {{#typeunknown}}
 {{anA}} {{assign}} graph that VI cannot process.<br>
 {{/typeunknown}}


### PR DESCRIPTION
Add the summary of the effect for expand_limits.

It will show how much the axis increases or state that there is no effect.

For example:
```
point = ggplot(economics, aes(x=psavert, y=uempmed )) + 
  geom_point() +
  expand_limits(y=30, x=3)
point
```
produces:
  >This is an untitled chart with no subtitle or caption.
It has x-axis 'psavert' with labels 5, 10 and 15.
It has y-axis 'uempmed' with labels 10, 20 and 30.
It has 2 layers.
Layer 1 is a set of 574 points.
Layer 2 is a expand limits, increasing y axis by 23%.


Talk about a bit of a tedious feature of ggplot!