### PR TITLE
0.33.4 closes #35 fix geom bar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 #BrailleR 0.33.4
--Add shaded area for geom_smooth CI info to VI output.
--Add geom_ribbon support
--Add geom_area support. This has been added to the geom_ribbon branch and is treated like a geom_ribbon almost exactly the same.
--Add support for showing expand_limit effect on graph.
+- Add shaded area for geom_smooth CI info to VI output.
+- Add geom_ribbon support
+- Add geom_area support. This has been added to the geom_ribbon branch and is treated like a geom_ribbon almost exactly the same.
+- Add support for showing expand_limit effect on graph.
 - add functionality for winget tools into new winget.R file; should streamline software installation down the track
 - deprecated functions relating to Python 2.7 and functions relating to making slide shows
+- fix issue #35 with incorrect bin counts
 
 # BrailleR 0.33.3
 -Update author files

--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -91,6 +91,30 @@
   #Vertical bars
   if (sum(layer$flipped_aes == T) == 0) {
     return("vertical")
+    #Horizontal bars
+  } else if (sum(layer$flipped_aes == T) == length(layer$count)) {
+    return("horizontal")
+  } else {
+    return("(error with orientation)")
+  }
+}
+
+#Get number of bars in a geom_bar
+.getNumOfBars = function(data, flipped_aes) {
+  #Vertical bars
+  if (flipped_aes == "vertical") {
+    min = data$xmin
+    max = data$xmax
+  #Horizontal bars
+  } else {
+    min = data$ymin
+    max = data$ymax
+  }
+  widths = vector()
+  for (i in 1:length(min)) {
+    widths[length(widths)+1] = paste(toString(min[i]), " to ", toString(max[i]))
+  }
+  length(unique(widths))
 }
 
 ## Scales

--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -85,11 +85,11 @@
 }
 
 #Bar Orientation
-.findBarOrientation = function(x, xbuild, layer) {
-  flipped = xbuild$plot$layers[[layer]]$geom_params$flipped_aes
-  if (rlang::is_true(flipped))
-    return("horizontal")
-  else
+# It is done by looking at the the flipped_aes in the build object
+.findBarOrientation = function(x, xbuild, layeri) {
+  layer = xbuild$data[[layeri]]
+  #Vertical bars
+  if (sum(layer$flipped_aes == T) == 0) {
     return("vertical")
 }
 

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -374,6 +374,9 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
       # as they won't be displayed
       cleandata = layer$data[!is.na(layer$data$xmin) & !is.na(layer$data$xmax),]
       # Recount rows
+      # Count how many bars are seen visually this is different
+      # to the number of actual bars as bars may be stacked on top of each other
+      layer$numberOfBars = .getNumOfBars(cleandata, layer$orientation)
       layer$n = nrow(cleandata)
       map = .mapDataValues(x, xbuild, list("x", "ymin", "ymax"), panel, 
                            list(x=cleandata$x, ymin=cleandata$ymin, ymax=cleandata$ymax))

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -79,7 +79,7 @@ Data values may be reported incorrectly.
 {{/largecount}}.<br>
 {{/typehline}}
 {{#typebar}}
-a bar chart with {{n}} {{orientation}} bar{{#s}}s{{/s}}.<br>
+a bar chart with {{numberOfBars}} {{orientation}} bar{{#s}}s{{/s}}.<br>
 {{^largecount}}
 {{#items}}Bar {{itemnum}}
 {{#xmin}} spans horizontally from {{xmin}} to {{xmax}}{{/xmin}}

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -82,9 +82,9 @@ Data values may be reported incorrectly.
 a bar chart with {{numberOfBars}} {{orientation}} bar{{#s}}s{{/s}}.<br>
 {{^largecount}}
 {{#items}}Bar {{itemnum}}
-{{#xmin}} spans horizontally from {{xmin}} to {{xmax}}{{/xmin}}
-{{^xmin}} is centered horizontally at {{x}}{{/xmin}}
-, and spans vertically from {{ymin}} to {{ymax}}
+{{#varyingWidths}} spans width from {{widthmin}} to {{widthmin}}{{/varyingWidths}}
+{{^varyingWidths}} is centered at {{loc}}{{/varyingWidths}}
+, and length is from {{min}} to {{max}}
 {{#fill}} with fill colour {{fill}}{{#fillmap}} which maps to {{filllabel}} = {{fillmap}}{{/fillmap}}{{/fill}}
 {{#colour}} with border colour {{colour}}{{#colourmap}} which maps to {{colourlabel}} = {{colourmap}}{{/colourmap}}{{/colour}}
 {{#linetype}} with border line type {{linetype}}{{#linetypemap}} which maps to {{linetypelabel}} = {{linetypemap}}{{/linetypemap}}{{/linetype}}


### PR DESCRIPTION
This fixes both the bar count and orientation problem. Closing #35 

For example this graph:
```
hist_flipped = ggplot(InsectSprays, aes(y=count)) +
  geom_histogram(aes(fill=spray), bins=5)
hist_flipped
```
Will show:
> This is an untitled chart with no subtitle or caption.
It has x-axis 'count' with labels 0, 5, 10, 15 and 20.
It has y-axis 'count' with labels 0, 10, 20 and 30.
There is a legend indicating fill is used to show spray, with 6 levels:
A shown as strong reddish orange fill, 
B shown as strong yellow fill, 
C shown as vivid yellowish green fill, 
D shown as brilliant bluish green fill, 
E shown as brilliant blue fill and 
F shown as vivid purple fill.
The chart is a bar chart with 5 horizontal bars.
These are stacked, as sorted by spray.