### PR TITLE
resolving #24

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # BrailleR 0.33.4
 - fix issue #35 with incorrect bin counts
+- fix issue #24, correcting base plot titles
 - Add shaded area for geom_smooth CI info to VI output.
 - Add geom_ribbon support
 - Add geom_area support. This has been added to the geom_ribbon branch and is treated like a geom_ribbon almost exactly the same.

--- a/R/VIMethod1_JG.R
+++ b/R/VIMethod1_JG.R
@@ -1,3 +1,17 @@
+### Internal functions for base R plots
+
+.getGraphName = function(graph, titlePreamble = "With the title:", noTitleMessage="With no title") {
+  if (length(graph$main) > 0 && nchar(gsub(" ", "",graph$main, fixed=T)) != 0) {
+    paste(titlePreamble,graph$main)
+  } else if (nchar(graph$ExtraArgs$main) > 0) {
+    paste(titlePreamble,graph$ExtraArgs$main)
+  } else {
+    noTitleMessage
+  }
+}
+
+
+###VI methods
 
 VI = function(x, Describe=FALSE, ...) {
        UseMethod("VI")
@@ -23,8 +37,7 @@ VI.boxplot =
 x=Augment(x)
       cat(paste0(
               'This graph has ', x$Boxplots, ' printed ', x$VertHorz,
-              '\n', ifelse(length(x$ExtraArgs$main) > 0, 'with the title: ',
-                           'but has no title'), x$ExtraArgs$main, '\n',
+              '\n', .getGraphName(x), '\n',
               ifelse(length(x$ExtraArgs$xlab) > 0, InQuotes(x$ExtraArgs$xlab), 'No label'),
               ' appears on the x-axis.\n',
               ifelse(length(x$ExtraArgs$ylab) > 0, paste0('"', x$ExtraArgs$ylab, '"'), 'No label'),
@@ -82,8 +95,7 @@ VI.dotplot =
       Cuts = seq(MinVal, MaxVal, (MaxVal - MinVal) / Bins)
       # now do the description bit
       cat(paste0('This graph has ', x$dotplots, ' printed ', x$VertHorz, '\n',
-                 ifelse(length(x$ExtraArgs$main) > 0, 'with the title: ',
-                        'but has no title'), x$ExtraArgs$main, '\n'))
+                 .getGraphName(x), '\n'))
       if (!is.null(x$ExtraArgs$dlab) | !is.null(x$ExtraArgs$glab)) {
         warning(
             "Use of dlab or glab arguments is not advised. Use xlab and ylab instead.")
@@ -111,8 +123,7 @@ VI.dotplot =
 
 VI.histogram =
     function(x, Describe=FALSE, ...) {
-      cat(paste0('This is a histogram, with the title: ',
-          ifelse(length(x$ExtraArgs$main) > 0, x$ExtraArgs$main, paste("Histogram of", x$xname)),
+      cat(paste0('This is a histogram, ', .getGraphName(x, titlePreamble = "with the title:"),
           '\n', ifelse(length(x$ExtraArgs$xlab) > 0, InQuotes(x$ExtraArgs$xlab), InQuotes(x$xname)),
           ' is marked on the x-axis.\n'))
       cat("Tick marks for the x-axis are at:", .GetAxisTicks(x$par$xaxp), "\n")


### PR DESCRIPTION
Fixing issues with base r plots with VI not picking up on the correct title. This is close #24 

This means that for a graph like
```
boxplot(x, main="This is the title")
```
It will get the title as "This is the title"

But for:
```
boxplot(x, main="   ")
#and
boxplot(x)
```
It wont get any title as there is no title on the plot.

There are some of the graphs like Hist that will almost always 
