### PR TITLE
resolve #31 add default shape description to geom_point

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - add functionality for winget tools into new winget.R file; should streamline software installation down the track
 - deprecated functions relating to Python 2.7 and functions for making slide shows
 - updated template files so that chunk options are moved from opening fence to commented lines
+- resolve issue #31, add default shape message.
 
 # BrailleR 0.33.3
 -Update author files

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -363,6 +363,15 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
         layer$transform = map$badTransform
       } 
       layer$scaledata = map$value
+      
+      # Check to see if the shape parameter has been set.
+      if (is.null(cleandata$aes_params[["shape"]])) {
+        # Make sure there is only one shape for all points
+        # We know this is the default from the previous conditional
+        if (length(unique(xbuild$data[[layeri]]$shape)) == 1) {
+          layer$defaultShape = .convertAes(data.frame(shape = xbuild$data[[layeri]]$shape[1]))$shape[1]
+        }
+      }
       # Also report on any aesthetic variables that vary across the layer
       layer = .addAesVars(x, xbuild, cleandata, layeri, layer, panel)
 

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -93,7 +93,7 @@ a bar chart with {{numberOfBars}} {{orientation}} bar{{#s}}s{{/s}}.<br>
 {{/largecount}}
 {{/typebar}}
 {{#typepoint}}
-a set of {{n}} point{{#s}}s{{/s}}.<br>
+a set of {{n}}{{#defaultShape}} {{defaultShape}}{{/defaultShape}} point{{#s}}s{{/s}}.<br>
 {{^largecount}}
 The points are at:<br>
 {{#items}}({{x}}, {{y}})


### PR DESCRIPTION
Add default shape geom_point message. This will close #31 

This means that
```
ggplot(cars, aes(speed, dist)) +
  geom_point()
```

will show
> This is an untitled chart with no subtitle or caption.
It has x-axis 'speed' with labels 5, 10, 15, 20 and 25.
It has y-axis 'dist' with labels 0, 25, 50, 75, 100 and 125.
The chart is a set of 50 big solid circle points.

