### PR TITLE
0.33.4 issue 77 ggplot coords vi

### DIFF
--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -36,12 +36,26 @@
 }
 
 ## Axes
+## This will get whether the plot is flipped or not
+.isGGCoordFlipped = function(x) {
+  return(sum("CoordFlip" %in% .getGGCoord(x)) > 0)
+}
+
 .getGGXLab = function(x, xbuild) {
-  return(x$labels$x)
+  if (.isGGCoordFlipped(x)) {
+    return(x$labels$y)
+  } else {
+    return(x$labels$x)
+  }
+
 }
 
 .getGGYLab = function(x, xbuild) {
-  return(x$labels$y)
+  if (.isGGCoordFlipped(x)) {
+    return(x$labels$x)
+  } else {
+    return(x$labels$y)
+  }
 }
 
 .getGGXTicks = function(x, xbuild, layer) {
@@ -81,7 +95,7 @@
 
 # Coordinates
 .getGGCoord = function(x, xbuild) {
-  return(class(x$coordinates)[1])
+  return(class(x$coordinates))
 }
 
 #Bar Orientation

--- a/R/VIInternals.R
+++ b/R/VIInternals.R
@@ -35,49 +35,39 @@
   return(invisible(text))
 }
 
-## Axes
-## This will get whether the plot is flipped or not
-.isGGCoordFlipped = function(x) {
-  return(sum("CoordFlip" %in% .getGGCoord(x)) > 0)
-}
-
-.getGGXLab = function(x, xbuild) {
-  if (.isGGCoordFlipped(x)) {
-    return(x$labels$y)
+.getGGAxisLab = function(x, xbuild, axis) {
+  if (!.isGGCoordFlipped(x)) {
+    # Make sure it has axis ticks for it to have a axis
+    if (is.null(.getGGTicks(x, xbuild, axis = axis)))
+      return(NULL)
+    else 
+      return(x$labels[[axis]])
   } else {
-    return(x$labels$x)
+    # Return the opposite of the axis because the coord are flipped
+    if (axis == 'y') {
+      return(x$labels$x)
+    } else {
+      return(x$labels$y)
+    }
   }
-
 }
 
-.getGGYLab = function(x, xbuild) {
-  if (.isGGCoordFlipped(x)) {
-    return(x$labels$x)
+.getGGTicks = function(x, xbuild, layer, axis) {
+  if (.getGGCoord(x, xbuild) == "CoordPolar") {
+    if (.isGGAxisTheta(x,axis)) {
+      labs = xbuild$layout$panel_params[[1]]$theta.labels
+    } else {
+      labs = xbuild$layout$panel_params[[1]]$r.labels
+    }
   } else {
-    return(x$labels$y)
+    labs = xbuild$layout$panel_params[[1]][[axis]]$get_labels()
   }
-}
+  if (all(labs[!is.na(labs)] != '')) {
+    return(labs[!is.na(labs)])
+  } else {
+    return(NULL)
+  }
 
-.getGGXTicks = function(x, xbuild, layer) {
-  # The location of this item is changing in an upcoming ggplot version
-  if ("panel_ranges" %in% names(xbuild$layout)) {
-    return(xbuild$layout$panel_ranges[[layer]]$x.labels)   # ggplot 2.2.1
-  }
-  else {
-    xlabs <- xbuild$layout$panel_params[[1]]$x$get_labels()
-    return (xlabs[!is.na(xlabs)])
-  }
-}
-
-.getGGYTicks = function(x, xbuild, layer) {
-  # The location of this item is changing in an upcoming ggplot version
-  if ("panel_ranges" %in% names(xbuild$layout)) {
-    return(xbuild$layout$panel_ranges[[layer]]$y.labels)   # ggplot 2.2.1
-  }
-  else {
-    ylabs <- xbuild$layout$panel_params[[1]]$y$get_labels()
-    return (ylabs[!is.na(ylabs)])
-  }
 }
 
 # Guides
@@ -95,7 +85,11 @@
 
 # Coordinates
 .getGGCoord = function(x, xbuild) {
-  return(class(x$coordinates))
+  coords = class(x$coordinates)
+  if (sum("CoordFlip" %in% coords) > 0) return("CoordFlip")
+  if (sum("CoordPolar" %in% coords) > 0) return("CoordPolar")
+  if (sum("CoordCartesian" %in% coords) > 0) return("CoordCartesian")
+  return('unknown')
 }
 
 #Bar Orientation
@@ -426,4 +420,32 @@
   numberOfVisiblePoints = data.frame(roundedPoints) |> distinct() |> nrow()
   numberOfPoints = length(roundedPoints$x)
   (numberOfVisiblePoints / numberOfPoints)
+}
+
+#####################################################################
+##-----------------Coordinate system helper functions--------------##
+#####################################################################
+
+
+##########################
+## Flipped coordinates
+##########################
+
+## Gets whether the plot is CoordFlip or not
+.isGGCoordFlipped = function(x) {
+  return(.getGGCoord(x) == "CoordFlip")
+}
+
+##########################
+## Polar coordinates
+##########################
+
+## Tests if the plot is GGCoordFlipped
+.isGGCoordPolar = function(x) {
+  return(.getGGCoord(x) == "CoordPolar")
+}
+
+## Tests if the given axis is the theta axis
+.isGGAxisTheta = function(x, axis) {
+  x$coordinates$theta == axis
 }

--- a/R/VIMethod3_TH.R
+++ b/R/VIMethod3_TH.R
@@ -218,8 +218,9 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
 .VIstruct.ggplot = function(x) {
   xbuild = suppressMessages(ggplot_build(x))
   # If this is a plot we really can't deal with, say so now
-  if (!(.getGGCoord(x, xbuild) %in% c("CoordCartesian", "CoordFixed"))) {
-    message("VI cannot process ggplot objects with flipped or non-Cartesian coordinates")
+  supportedClasses = c("CoordCartesian", "CoordFixed")
+  if (!sum(supportedClasses %in% .getGGCoord(x, xbuild)) > 0) {
+    message("VI cannot process ggplot objects with non-Cartesian coordinates")
     return(NULL)
   }
   title = .getGGTitle(x, xbuild)
@@ -245,7 +246,8 @@ VI.ggplot = function(x, Describe=FALSE, threshold=10, template=system.file("whis
   panelcols = as.list(.getGGFacetCols(x, xbuild))
   layerCount = .getGGLayerCount(x, xbuild);
   VIstruct = .VIlist(annotations=annotations, xaxis=xaxis, yaxis=yaxis, legends=legends, panels=panels,
-                     npanels=length(panels), nlayers=layerCount, panelrows=panelrows, panelcols=panelcols, type="ggplot")
+                     npanels=length(panels), nlayers=layerCount,
+                     panelrows=panelrows, panelcols=panelcols, flippedCoord=.isGGCoordFlipped(x), type="ggplot")
   class(VIstruct) = "VIstruct"
   return(VIstruct)
 }

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -25,7 +25,8 @@ This is an untitled chart with no subtitle or caption.<br>
 {{#yaxis}}{{^singlepanel}}Each sub-chart{{/singlepanel}}{{#singlepanel}}It{{/singlepanel}} has y-axis '{{ylabel}}'
 {{#samescale}} with labels {{#ytickitems}}{{label}}{{sep}}{{/ytickitems}}{{/samescale}}
 .<br>{{/yaxis}}
-{{#flippedCoord}}The cartesian coordinates are flipped so everything below is flipped x is replaced with y and vice versa. The following information may be misleading.<br>{{/flippedCoord}}
+{{#CoordPolar}}The coordinates have been converted to polar coordinates with theta as {{PolarTheta}} and radius as {{PolarR}}.<br>{{/CoordPolar}}
+{{#CoordFlip}}The cartesian coordinates are flipped so everything below is flipped x is replaced with y and vice versa. The following information may be misleading.<br>{{/CoordFlip}}
 {{#legends}}
 {{^hidden}}There is a legend indicating {{aes}} is used to show {{mapping}}
 {{#scalediscrete}}, with {{scalenlevels}} levels:

--- a/inst/whisker/VIdefault.txt
+++ b/inst/whisker/VIdefault.txt
@@ -25,6 +25,7 @@ This is an untitled chart with no subtitle or caption.<br>
 {{#yaxis}}{{^singlepanel}}Each sub-chart{{/singlepanel}}{{#singlepanel}}It{{/singlepanel}} has y-axis '{{ylabel}}'
 {{#samescale}} with labels {{#ytickitems}}{{label}}{{sep}}{{/ytickitems}}{{/samescale}}
 .<br>{{/yaxis}}
+{{#flippedCoord}}The cartesian coordinates are flipped so everything below is flipped x is replaced with y and vice versa. The following information may be misleading.<br>{{/flippedCoord}}
 {{#legends}}
 {{^hidden}}There is a legend indicating {{aes}} is used to show {{mapping}}
 {{#scalediscrete}}, with {{scalenlevels}} levels:


### PR DESCRIPTION
Add support for both coord flip and coord polar.
There is also some cleanup and refactoring for internal working to make it more suited to having different coordinates.
It is quite basic and only adds a single sentence to the VI() output but it advises the user and then they can interpret the rest.

For example
```
ggplot(mtcars, aes(x= "", y = cyl, fill = as.factor(cyl))) +
  geom_col() + 
  coord_polar(theta= "y")
```
makes 
>This is an untitled chart with no subtitle or caption.
There is no x-axis.
It has y-axis 'cyl' with labels 0, 50, 100 and 150.
The coordinates have been converted to polar coordinates with theta as y and radius as x.
There is a legend indicating fill is used to show as.factor(cyl), with 3 levels:
4 shown as strong reddish orange fill, 
6 shown as vivid yellowish green fill and 
8 shown as brilliant blue fill.
The chart is a bar chart with 1 vertical bars.
These are stacked, as sorted by as.factor(cyl).

Then for flipped it even simpler
```
point_flipped = ggplot(mtcars, aes(mpg,disp)) +
  geom_point() + coord_flip()
point_flipped
```
would produce
>This is an untitled chart with no subtitle or caption.
It has x-axis 'disp' with labels 100, 200, 300 and 400.
It has y-axis 'mpg' with labels 10, 15, 20, 25, 30 and 35.
The cartesian coordinates are flipped so everything below is flipped x is replaced with y and vice versa. The following information may be misleading.
The chart is a set of 32 big solid circle points of which about 97% can be seen.
