### PR TITLE
0.33.4 Update TimeSeriesPlot to handle being given just a data vector.

### DIFF
--- a/R/TSPlot.R
+++ b/R/TSPlot.R
@@ -34,6 +34,9 @@ TimeSeriesPlot = function(.data, x, time=NULL, base=FALSE, ...){
       x = .data$Y
       #Get correct ylab
       Out$ylab = ifelse(is.null(MC$ylab[[1]]), deparse(MC$.data), MC$ylab)
+    } else if (!is.data.frame(.data)) {
+      x = .data
+      .data = data.frame(x=x)
     }
     
     if (is.null(time)) time = 1:length(x)


### PR DESCRIPTION
Currently, it can only handle being a data frame or a time series object. Now you can give it a simple vector and it will just make a line graph of it.

Now for example this will work: `TimeSeriesPlot(rnorm(1e2))` where it previously did not.
