### PR TITLE
Use the `meta` argument instead of `stylesheet` to pass CSS

### DIFF
--- a/R/OneFactor.R
+++ b/R/OneFactor.R
@@ -247,7 +247,7 @@ print(xtable(MyANOVA, caption=TabCapt, label="',
 
       # finish writing markdown and process the written file into html and an R script
       knit2html(Filename, quiet = TRUE,
-                stylesheet = FindCSSFile(getOption("BrailleR.Style")))
+                meta = list(css = FindCSSFile(getOption("BrailleR.Style"))))
       file.remove(sub(".Rmd", ".md", Filename))
       purl(Filename, quiet = TRUE, documentation = 0)
       if (View) browseURL(sub(".Rmd", ".html", Filename))


### PR DESCRIPTION
The `stylesheet` argument will be deprecated in future: https://github.com/rstudio/markdown/blob/master/NEWS.md#changes-in-markdown-version-13

Thanks!