### PR TITLE
Remove all but one note from cmd check

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^CONDUCT\.md$
 ^\.Rproj\.user$
 ^\.github$
+^\.pre-commit-config\.yaml$
 ^_pkgdown\.yml$
 ^cran-comments\.md$
 ^docs$

--- a/R/RewriteSVG.R
+++ b/R/RewriteSVG.R
@@ -315,7 +315,7 @@
 }
 
 .SplitPolyPoints.default <- function(points, polyType, nSections) {
-  warning(paste("Sorry type '", class(type), "' is not supported yet"))
+  warning(paste("Sorry type '", class(polyType), "' is not supported yet"))
   points
 }
 


### PR DESCRIPTION
Now there should be no notes except for the one that mentions removing package dependencies and the emmeans package.

The note about no visible binding for global variable was removed by using the `.data$` prefix for data.frame variables in tidyverse pipelines.

I have added the pre commit file to build ignore.